### PR TITLE
Replaced #ifdef _MSC_VER with #ifdef _WIN32; enables MinGW build.

### DIFF
--- a/src/ps3eye.cpp
+++ b/src/ps3eye.cpp
@@ -779,7 +779,7 @@ bool PS3EYECam::init(uint32_t width, uint32_t height, uint8_t desiredFrameRate)
 	ov534_reg_write(0xe7, 0x3a);
 	ov534_reg_write(0xe0, 0x08);
 
-#ifdef _MSC_VER
+#if defined WIN32 || defined _WIN32 || defined WINCE
 	Sleep(100);
 #else
     nanosleep((struct timespec[]){{0, 100000000}}, NULL);
@@ -790,7 +790,7 @@ bool PS3EYECam::init(uint32_t width, uint32_t height, uint8_t desiredFrameRate)
 
 	/* reset sensor */
 	sccb_reg_write(0x12, 0x80);
-#ifdef _MSC_VER
+#if defined WIN32 || defined _WIN32 || defined WINCE
 	Sleep(10);
 #else    
     nanosleep((struct timespec[]){{0, 10000000}}, NULL);


### PR DESCRIPTION
Replaced #ifdef _MSC_VER with #ifdef conditions used for windows include. This enables building with MinGW.
```
mkdir build
cd build
g++ -c -o ps3eye.o ..\src\ps3eye.cpp -I..\src\
```