### PR TITLE
Better fix for multiple libusb devices in Windows 8.1 & Win7 too.

### DIFF
--- a/sdl/README.mingw64
+++ b/sdl/README.mingw64
@@ -21,7 +21,7 @@ Prerequisites
 	Download the latest Development Libraries from http://www.libsdl.org/download-2.0.php (Tested with SDL2-devel-2.0.3-mingw.tar.gz)
 	Unpack next to PS3EYEDriver.
 	Rename the directory to SDL2.
-	Move the include files so that #include <SDL/xxx.h> works.
+	Move the include files so that #include <SDL2/xxx.h> works.
 		`mkdir ../../SDL2/include/SDL2`
 		`mv ../../SDL2/include/* ../../SDL2/include/SDL2/`
 		

--- a/sdl/main.cpp
+++ b/sdl/main.cpp
@@ -78,11 +78,7 @@ struct ps3eye_context {
         , last_frames(0)
     {
         if (hasDevices()) {
-			#ifdef _WIN32
-			eye = devices[1];
-			#else
             eye = devices[0];
-			#endif
             eye->init(width, height, fps);
         }
     }

--- a/src/ps3eye.cpp
+++ b/src/ps3eye.cpp
@@ -399,6 +399,7 @@ int USBMgr::listDevices( std::vector<PS3EYECam::PS3EYERef>& list )
 {
     libusb_device *dev;
     libusb_device **devs;
+    libusb_device_handle *devhandle;
     int i = 0;
     int cnt;
 
@@ -414,9 +415,14 @@ int USBMgr::listDevices( std::vector<PS3EYECam::PS3EYERef>& list )
 		libusb_get_device_descriptor(dev, &desc);
 		if(desc.idVendor == PS3EYECam::VENDOR_ID && desc.idProduct == PS3EYECam::PRODUCT_ID)
 		{
-			list.push_back( PS3EYECam::PS3EYERef( new PS3EYECam(dev) ) );
-			libusb_ref_device(dev);
-			cnt++;
+            int err = libusb_open(dev, &devhandle);
+            if (err == 0)
+            {
+                libusb_close(devhandle);
+                list.push_back( PS3EYECam::PS3EYERef( new PS3EYECam(dev) ) );
+                libusb_ref_device(dev);
+                cnt++;
+            }
 		}
     }
 


### PR DESCRIPTION
First commit reverts a Windows-specific hack in the SDL example to open the second device instead of the first. However, the two-device problem only appears in Windows 8.1.

The second commit tries to open every device that meets the PID and VID and only includes those devices that can actually be opened.

Now this works for both Windows 7 and Windows 8.1.