### PR TITLE
Fix compilation in Visual Studio 2013.

### DIFF
--- a/src/ps3eye.cpp
+++ b/src/ps3eye.cpp
@@ -3,6 +3,7 @@
 
 #if defined WIN32 || defined _WIN32 || defined WINCE
 	#include <windows.h>
+	#include <algorithm>
 #else
 	#include <sys/time.h>
 	#include <time.h>

--- a/src/ps3eye.h
+++ b/src/ps3eye.h
@@ -30,9 +30,9 @@
 #include <stdint.h>
 
 #if defined(DEBUG)
-#define debug(x...) fprintf(stdout,x)
+#define debug(x,...) fprintf(stdout,x)
 #else
-#define debug(x...) 
+#define debug(x,...) 
 #endif
 
 


### PR DESCRIPTION
A couple small changes necessary for compilation in MSVC (tested in 2013).
These changes were also tested in OSX and MinGW.