### PR TITLE
Fixes for homebrew gcc. Also fixes a previous MinGW problem.

### DIFF
--- a/src/ps3eye.cpp
+++ b/src/ps3eye.cpp
@@ -779,10 +779,10 @@ bool PS3EYECam::init(uint32_t width, uint32_t height, uint8_t desiredFrameRate)
 	ov534_reg_write(0xe7, 0x3a);
 	ov534_reg_write(0xe0, 0x08);
 
-#if defined WIN32 || defined _WIN32 || defined WINCE
+#if _MSC_VER
 	Sleep(100);
 #else
-    nanosleep((struct timespec[]){{0, 100000000}}, NULL);
+    nanosleep((const struct timespec[]){{0, 100000000}}, NULL);
 #endif
 
 	/* initialize the sensor address */
@@ -790,10 +790,10 @@ bool PS3EYECam::init(uint32_t width, uint32_t height, uint8_t desiredFrameRate)
 
 	/* reset sensor */
 	sccb_reg_write(0x12, 0x80);
-#if defined WIN32 || defined _WIN32 || defined WINCE
+#if _MSC_VER 
 	Sleep(10);
 #else    
-    nanosleep((struct timespec[]){{0, 10000000}}, NULL);
+    nanosleep((const struct timespec[]){{0, 10000000}}, NULL);
 #endif
 
 	/* probe the sensor */

--- a/src/ps3eye.cpp
+++ b/src/ps3eye.cpp
@@ -779,7 +779,7 @@ bool PS3EYECam::init(uint32_t width, uint32_t height, uint8_t desiredFrameRate)
 	ov534_reg_write(0xe7, 0x3a);
 	ov534_reg_write(0xe0, 0x08);
 
-#if _MSC_VER
+#ifdef _MSC_VER
 	Sleep(100);
 #else
     nanosleep((const struct timespec[]){{0, 100000000}}, NULL);
@@ -790,7 +790,7 @@ bool PS3EYECam::init(uint32_t width, uint32_t height, uint8_t desiredFrameRate)
 
 	/* reset sensor */
 	sccb_reg_write(0x12, 0x80);
-#if _MSC_VER 
+#ifdef _MSC_VER 
 	Sleep(10);
 #else    
     nanosleep((const struct timespec[]){{0, 10000000}}, NULL);

--- a/src/ps3eye.h
+++ b/src/ps3eye.h
@@ -3,6 +3,7 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <vector>
 
 // define shared_ptr in std 


### PR DESCRIPTION
The previous MinGW fix b637fc6bc386b1da30e14befea8ec70b950f6911 is no longer necessary.

This was tested with homebrew gcc 4.9 and MinGW 4.9.