### PR TITLE
Debug sdl

### DIFF
--- a/sdl/makefile
+++ b/sdl/makefile
@@ -33,5 +33,9 @@ endif
 $(TARGET): $(OBJECTS)
 	$(CXX) -o $@ $^ $(LIBS)
 
+debug: CXXFLAGS += -DDEBUG -g
+debug: CCFLAGS += -DDEBUG -g
+debug: $(TARGET)
+
 clean:
 	rm -f $(TARGET) $(OBJECTS)

--- a/src/ps3eye.h
+++ b/src/ps3eye.h
@@ -31,9 +31,9 @@
 #include <stdint.h>
 
 #if defined(DEBUG)
-#define debug(x,...) fprintf(stdout,x)
+#define debug(...) fprintf(stdout, __VA_ARGS__)
 #else
-#define debug(x,...) 
+#define debug(...) 
 #endif
 
 


### PR DESCRIPTION
My previous changes to the debug macro did not necessarily work in all environments. The new version should be more compatible.

I added a debug target to the SDL example makefile.