### PR TITLE
SDL example changes: Include SDL now the same for Windows and OS X

### DIFF
--- a/sdl/README.mingw64
+++ b/sdl/README.mingw64
@@ -12,19 +12,16 @@ Prerequisites
 	For this simple project, bash is only necessary to get `mingw32-make clean` to work. Everything else should work from command prompt.
 
 3. libusb-1.0
-	Download the latest Windows binaries from http://libusb.info/ (Tested with libusb-1.0.19-rc1-win)
+	Download the latest Windows binaries from http://libusb.info/ (Tested with libusb-1.0.20)
 	Unpack next to PS3EYEDriver.
 	Rename the directory to libusb-1.0 (i.e., cut off the version number).
 	See below for directory layout.
 	
 4. SDL2
-	Download the latest Development Libraries from http://www.libsdl.org/download-2.0.php (Tested with SDL2-devel-2.0.3-mingw.tar.gz)
+	Download the latest Development Libraries from http://www.libsdl.org/download-2.0.php (Tested with SDL2-devel-2.0.4-mingw.tar.gz)
 	Unpack next to PS3EYEDriver.
 	Rename the directory to SDL2.
-	Move the include files so that #include <SDL2/xxx.h> works.
-		`mkdir ../../SDL2/include/SDL2`
-		`mv ../../SDL2/include/* ../../SDL2/include/SDL2/`
-		
+
 5. A windows libusb interface to your PS3Eye
 	Read here: https://github.com/libusb/libusb/wiki/Windows#How_to_use_libusb_on_Windows
 	I used Zadig to install drivers for my camera. This was a little trickier than expected.
@@ -45,7 +42,6 @@ Necessary directory structure
 	-x86_64-w64-mingw32
 		-bin
 		-include
-			-SDL2
 		-lib
 
 Build

--- a/sdl/main.cpp
+++ b/sdl/main.cpp
@@ -4,7 +4,7 @@
  * Joseph Howse <josephhowse@nummist.com>; 2014-12-26
  **/
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include "ps3eye.h"
 
 
@@ -141,7 +141,7 @@ print_renderer_info(SDL_Renderer *renderer)
 int
 main(int argc, char *argv[])
 {
-    ps3eye_context ctx(320, 240, 187);
+    ps3eye_context ctx(640, 480, 60);
     if (!ctx.hasDevices()) {
         printf("No PS3 Eye camera connected\n");
         return EXIT_FAILURE;


### PR DESCRIPTION
Also changed SDL example camera settings to 640x480@60fps.

For MinGW64, previously we were including SDL2 from a subfolder within the SDL2/include path, a subfolder that had to be manually created as described in the README.mingw64. I can't remember now, but I think was done to be in-line with thp's SDL example. However, this is not in-line with how things are done in OS X when using `brew install sdl2`.

So, in the interest of simplicity, I've removed the extra steps in the README and made the SDL include the same for mingw64 and OS X.

I also changed the default frame size and frame rate for the SDL example. 640x480@60fps is taxing on the system but this feature is probably the main reason anyone would want to use PS3 Eye, so it should be the default in the example so users can easily see if it works for them.