### PR TITLE
Fix for glitching when frame rate is too high

### DIFF
--- a/src/ps3eye.cpp
+++ b/src/ps3eye.cpp
@@ -766,7 +766,8 @@ public:
 	        if (this_pts != last_pts || this_fid != last_fid) {
 	            if (last_packet_type == INTER_PACKET)
 	            {
-	                frame_add(LAST_PACKET, NULL, 0);
+	                /* The last frame was incomplete, so don't keep it or we will glitch */
+	                frame_add(DISCARD_PACKET, NULL, 0);
 	            }
 	            last_pts = this_pts;
 	            last_fid = this_fid;


### PR DESCRIPTION
This drops all the glitched frames that occur and are added as frame when running at 640x480x60fps on my Windows 7 machine.
It seems that line 767 should also check for last_packet_type == FIRST_PACKET and discard in that case too, but I'm not seeing that case actually happening.

I'm not sure what the original intent of marking this as LAST_PACKET was (a mistake?)... at least my ps3eye doesn't seem to ever do anything good when we get to this line of code.