### PR TITLE
Adding method to get a unique ID for the PS3Eye

### DIFF
--- a/src/ps3eye.h
+++ b/src/ps3eye.h
@@ -151,6 +151,9 @@ public:
     
 
     bool isStreaming() const { return is_streaming; }
+    bool isInitialized() const { return device_ != NULL && handle_ != NULL && usb_buf != NULL; }
+
+	bool getUSBPortPath(char *out_identifier, size_t max_identifier_length) const;
 	
 	// Get a frame from the camera. Notes:
 	// - If there is no frame available, this function will block until one is

--- a/src/ps3eye_capi.cpp
+++ b/src/ps3eye_capi.cpp
@@ -118,6 +118,26 @@ ps3eye_open(int id, int width, int height, int fps, ps3eye_format outputFormat)
     return new ps3eye_t(ps3eye_context->devices[id], width, height, fps, outputFormat);
 }
 
+int
+ps3eye_get_unique_identifier(ps3eye_t * eye_t, char *out_identifier, int max_identifier_length)
+{
+    if (!ps3eye_context) 
+    {
+        // No context available
+        return -1;
+    }
+    
+    if (!eye_t) 
+    {
+        // Eye is not a valid handle
+        return -1;
+    }
+
+    bool success = eye_t->eye->getUSBPortPath(out_identifier, max_identifier_length);
+
+    return success ? 0 : -1;
+}
+
 void
 ps3eye_grab_frame(ps3eye_t *eye, unsigned char* frame)
 {

--- a/src/ps3eye_capi.h
+++ b/src/ps3eye_capi.h
@@ -88,6 +88,13 @@ ps3eye_t *
 ps3eye_open(int id, int width, int height, int fps, ps3eye_format outputFormat);
 
 /**
+ * Get the string that uniquely identifies this camera
+ * Returns 0 on success, -1 on failure
+ **/
+int
+ps3eye_get_unique_identifier(ps3eye_t * eye, char *out_identifier, int max_identifier_length);
+
+/**
  * Grab the next frame as YUV422 blob.
  * A pointer to the buffer will be passed back. The buffer
  * will only be valid until the next call, or until the eye


### PR DESCRIPTION
* Uses the USB Bus/Port path from libusb to uniquely identify a camera by the USB port it's plugged into.
* Useful for multicam situations where you need to store configuration options per camera.