### PR TITLE
More FPS modes, ranging from 2 to 290

### DIFF
--- a/sdl/main.cpp
+++ b/sdl/main.cpp
@@ -18,7 +18,7 @@ struct ps3eye_context {
     {
         if (hasDevices()) {
             eye = devices[0];
-            eye->init(width, height, (uint8_t)fps);
+            eye->init(width, height, (uint16_t)fps);
         }
     }
 
@@ -181,10 +181,10 @@ main(int argc, char *argv[])
 
 	if (mode_test)
 	{
-		int rates_qvga[] = { 15, 20, 30, 40, 50, 60, 75, 90, 100, 125, 137, 150, 187 };
+		int rates_qvga[] = { 2, 3, 5, 7, 10, 12, 15, 17, 30, 37, 40, 50, 60, 75, 90, 100, 125, 137, 150, 187 };
 		int num_rates_qvga = sizeof(rates_qvga) / sizeof(int);
 
-		int rates_vga[] = { 15, 20, 30, 40, 50, 60, 75 };
+		int rates_vga[] = { 2, 3, 5, 8, 10, 15, 20, 25, 30, 40, 50, 60, 75 };
 		int num_rates_vga = sizeof(rates_vga) / sizeof(int);
 
 		for (int index = 0; index < num_rates_qvga; ++index)

--- a/src/ps3eye.cpp
+++ b/src/ps3eye.cpp
@@ -325,8 +325,8 @@ std::shared_ptr<USBMgr> USBMgr::sInstance;
 int                     USBMgr::sTotalDevices = 0;
 
 USBMgr::USBMgr() :
-	exit_signaled({ false }),
-	active_camera_count({ 0 })
+	exit_signaled(false),
+	active_camera_count(0)
 {
     libusb_init(&usb_context);
     libusb_set_debug(usb_context, 1);
@@ -935,7 +935,7 @@ void PS3EYECam::release()
 	if(usb_buf) free(usb_buf);
 }
 
-bool PS3EYECam::init(uint32_t width, uint32_t height, uint8_t desiredFrameRate, EOutputFormat outputFormat)
+bool PS3EYECam::init(uint32_t width, uint32_t height, uint16_t desiredFrameRate, EOutputFormat outputFormat)
 {
 	uint16_t sensor_id;
 
@@ -1173,40 +1173,55 @@ void PS3EYECam::ov534_set_led(int status)
 }
 
 /* validate frame rate and (if not dry run) set it */
-uint8_t PS3EYECam::ov534_set_frame_rate(uint8_t frame_rate, bool dry_run)
+uint16_t PS3EYECam::ov534_set_frame_rate(uint16_t frame_rate, bool dry_run)
 {
      int i;
      struct rate_s {
-             uint8_t fps;
+             uint16_t fps;
              uint8_t r11;
              uint8_t r0d;
              uint8_t re5;
      };
      const struct rate_s *r;
      static const struct rate_s rate_0[] = { /* 640x480 */
-			 {75, 0x01, 0x81, 0x02},
+             {83, 0x01, 0xc1, 0x02}, /* 83 FPS: video is partly corrupt */
+             {75, 0x01, 0x81, 0x02}, /* 75 FPS or below: video is valid */
              {60, 0x00, 0x41, 0x04},
              {50, 0x01, 0x41, 0x02},
              {40, 0x02, 0xc1, 0x04},
              {30, 0x04, 0x81, 0x02},
-			 {20, 0x04, 0x41, 0x02},
+             {25, 0x00, 0x01, 0x02},
+             {20, 0x04, 0x41, 0x02},
              {15, 0x09, 0x81, 0x02},
+             {10, 0x09, 0x41, 0x02},
+             {8, 0x02, 0x01, 0x02},
+             {5, 0x04, 0x01, 0x02},
+             {3, 0x06, 0x01, 0x02},
+             {2, 0x09, 0x01, 0x02},
      };
      static const struct rate_s rate_1[] = { /* 320x240 */
-             {205, 0x01, 0xc1, 0x02}, /* 205 FPS: video is partly corrupt */
+             {290, 0x00, 0xc1, 0x04},
+             {205, 0x01, 0xc1, 0x02}, /* 205 FPS or above: video is partly corrupt */
              {187, 0x01, 0x81, 0x02}, /* 187 FPS or below: video is valid */
              {150, 0x00, 0x41, 0x04},
-			 {137, 0x02, 0xc1, 0x02},
+             {137, 0x02, 0xc1, 0x02},
              {125, 0x01, 0x41, 0x02},
              {100, 0x02, 0xc1, 0x04},
-			 {90, 0x03, 0x81, 0x02},
+             {90, 0x03, 0x81, 0x02},
              {75, 0x04, 0x81, 0x02},
              {60, 0x04, 0xc1, 0x04},
              {50, 0x04, 0x41, 0x02},
              {40, 0x06, 0x81, 0x03},
+             {37, 0x00, 0x01, 0x04},
              {30, 0x04, 0x41, 0x04},
-			 {20, 0x18, 0xc1, 0x02},
-			 {15, 0x18, 0x81, 0x02},
+             {17, 0x18, 0xc1, 0x02},
+             {15, 0x18, 0x81, 0x02},
+             {12, 0x02, 0x01, 0x04},
+             {10, 0x18, 0x41, 0x02},
+             {7, 0x04, 0x01, 0x04},
+             {5, 0x06, 0x01, 0x04},
+             {3, 0x09, 0x01, 0x04},
+             {2, 0x18, 0x01, 0x02},
      };
 
      if (frame_width == 640) {

--- a/src/ps3eye.h
+++ b/src/ps3eye.h
@@ -44,7 +44,7 @@ public:
 	PS3EYECam(libusb_device *device);
 	~PS3EYECam();
 
-	bool init(uint32_t width = 0, uint32_t height = 0, uint8_t desiredFrameRate = 30, EOutputFormat outputFormat = EOutputFormat::BGR);
+	bool init(uint32_t width = 0, uint32_t height = 0, uint16_t desiredFrameRate = 30, EOutputFormat outputFormat = EOutputFormat::BGR);
 	void start();
 	void stop();
 
@@ -162,7 +162,7 @@ public:
 
 	uint32_t getWidth() const { return frame_width; }
 	uint32_t getHeight() const { return frame_height; }
-	uint8_t getFrameRate() const { return frame_rate; }
+	uint16_t getFrameRate() const { return frame_rate; }
 	uint32_t getRowBytes() const { return frame_width * getOutputBytesPerPixel(); }
 	uint32_t getOutputBytesPerPixel() const;
 
@@ -176,7 +176,7 @@ private:
 	void release();
 
 	// usb ops
-	uint8_t ov534_set_frame_rate(uint8_t frame_rate, bool dry_run = false);
+	uint16_t ov534_set_frame_rate(uint16_t frame_rate, bool dry_run = false);
 	void ov534_set_led(int status);
 	void ov534_reg_write(uint16_t reg, uint8_t val);
 	uint8_t ov534_reg_read(uint16_t reg);
@@ -210,7 +210,7 @@ private:
 
 	uint32_t frame_width;
 	uint32_t frame_height;
-	uint8_t frame_rate;
+	uint16_t frame_rate;
 	EOutputFormat frame_output_format;
 
 	//usb stuff


### PR DESCRIPTION
I have added more FPS modes, including the following:

VGA: 83\*, 10, 8, 5, 3, and 2 FPS
QVGA: 290\*, 12, 10, 7, 5, 3, and 2 FPS

\* At these high-speed modes, the frame is partly corrupt.

To support high-speed modes, I have changed the type of the frame rate variables from uint8_t to uint16_t.

The slow-speed modes are useful for low-light work because they allow a slower shutter speed and thus a brighter image.