### PR TITLE
Added setFrameRate to change the frame rate of an open PS Eye camera

### DIFF
--- a/src/ps3eye.h
+++ b/src/ps3eye.h
@@ -173,6 +173,11 @@ public:
 	uint32_t getWidth() const { return frame_width; }
 	uint32_t getHeight() const { return frame_height; }
 	uint16_t getFrameRate() const { return frame_rate; }
+	bool setFrameRate(uint8_t val) {
+		if (is_streaming) return false;
+		frame_rate = ov534_set_frame_rate(val, true);
+		return true;
+	}
 	uint32_t getRowBytes() const { return frame_width * getOutputBytesPerPixel(); }
 	uint32_t getOutputBytesPerPixel() const;
 


### PR DESCRIPTION
Added the ability to change the frame rate of an open camera by stopping it, changing the frame rate then restarting it. This was added for use with PSMoveService and makes it very easy to lower the frame rate in order to reduce the USB bandwidth required.