### PR TITLE
Added functions to set the resolution if the camera is not streaming

### DIFF
--- a/src/ps3eye.h
+++ b/src/ps3eye.h
@@ -171,7 +171,33 @@ public:
 	void getFrame(uint8_t* frame);
 
 	uint32_t getWidth() const { return frame_width; }
+	bool setWidth(uint32_t width) {
+		if (is_streaming) return false;
+		if (width == 0 || width > 320)
+		{
+			frame_width = 640;
+			frame_height = 480;
+		}
+		else {
+			frame_width = 320;
+			frame_height = 240;
+		}
+		return true;
+	}
 	uint32_t getHeight() const { return frame_height; }
+	bool setHeight(uint32_t height) {
+		if (is_streaming) return false;
+		if (height == 0 || height > 240)
+		{
+			frame_width = 640;
+			frame_height = 480;
+		}
+		else {
+			frame_width = 320;
+			frame_height = 240;
+		}
+		return true;
+	}
 	uint16_t getFrameRate() const { return frame_rate; }
 	bool setFrameRate(uint8_t val) {
 		if (is_streaming) return false;


### PR DESCRIPTION
The width and height can independantly be specified and the other
variable will be set to it's corresponding value. This will return true
if the camera is not streaming and will return false (and not apply any
values) if the camera is in use.

This has been added with a similar method to setFrameRate (and again 
for PSMoveService) so hopefully there should be no issues with it.