### PR TITLE
RGBA format and fixed RGB debayer with vertical flip

### DIFF
--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -1,0 +1,43 @@
+cmake_minimum_required(VERSION 2.6)
+
+set(CMAKE_CXX_STANDARD 14)
+
+set(HAS_LIBPS3EYE 1 PARENT_SCOPE)
+message("setting HAS_LIBPS3EYE")
+
+# --- dependencies ---
+
+if (NOT HAS_LIBGG)
+	message("including libgg")
+	add_subdirectory(../../../libgg libgg)
+endif (NOT HAS_LIBGG)
+if (NOT HAS_FRAMEWORK)
+	message("including framework")
+	add_subdirectory(../../../framework framework)
+endif (NOT HAS_FRAMEWORK)
+
+#
+
+project(libps3eye)
+
+# --- libps3eye ---
+
+file(GLOB_RECURSE source "../src/*.*")
+
+add_library(libps3eye ${source})
+
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules)
+
+find_package(PkgConfig)
+find_package(LibUSB REQUIRED)
+
+target_include_directories(libps3eye PUBLIC "${PROJECT_SOURCE_DIR}/../src")
+target_include_directories(libps3eye PRIVATE "${PROJECT_SOURCE_DIR}" "${LibUSB_INCLUDE_DIRS}")
+
+target_link_libraries(libps3eye PRIVATE libgg ${LibUSB_LIBRARIES})
+
+#
+
+add_executable(example main.cpp)
+
+target_link_libraries(example PRIVATE libps3eye framework ${FRAMEWORK_LIBRARIES})

--- a/framework/README.md
+++ b/framework/README.md
@@ -1,0 +1,4 @@
+PS3EYE Driver
+========
+
+Library and example for [framework](https://github.com/marcel303/framework), the free and open source creative coding library.

--- a/framework/audio.cpp
+++ b/framework/audio.cpp
@@ -124,37 +124,6 @@ static void drawAudioHistory(const MyAudioCallback & audioCallback)
 	gxPopMatrix();
 }
 
-#if 0 // todo : remove
-
-static void testAudioStreaming(PS3EYECam * eye)
-{
-	const int testDuration = 10; // seconds
-	const int historySize = 1; // seconds
-	
-	PS3EYEMic mic;
-	MyAudioCallback audioCallback(historySize);
-	
-	if (mic.init(eye->getDevice(), &audioCallback))
-	{
-		const auto endTime = SDL_GetTicks() + testDuration * 1000;
-		
-		while (SDL_GetTicks() < endTime && !keyboard.wentDown(SDLK_SPACE))
-		{
-			framework.process();
-			
-			framework.beginDraw(0, 0, 0, 0);
-			{
-				drawAudioHistory(audioCallback);
-			}
-			framework.endDraw();
-		}
-		
-		mic.shut();
-	}
-}
-
-#endif
-
 int main(int argc, char * argv[])
 {
 	if (!framework.init(0, nullptr, 640, 480))
@@ -172,13 +141,6 @@ int main(int argc, char * argv[])
 		eye = devices[0];
 	
 	devices.clear();
-
-#if 0 // todo : remove
-	if (eye != nullptr)
-	{
-		testAudioStreaming(eye.get());
-	}
-#endif
 	
 	if (eye != nullptr)
 	{

--- a/framework/audio.cpp
+++ b/framework/audio.cpp
@@ -170,7 +170,7 @@ int main(int argc, char * argv[])
 		logError("error: %s", errorString.c_str());
 	}
 	
-	GLuint texture = 0;
+	GxTexture texture;
 	
 	bool stressTest = false;
 	
@@ -198,32 +198,27 @@ int main(int argc, char * argv[])
 			
 			//
 			
-			if (texture != 0)
-				glDeleteTextures(1, &texture);
-			
 			if (CAM_GRAYSCALE)
 			{
-				texture = createTextureFromR8(imageData, CAM_SX, CAM_SY, false, true);
-				
-				glBindTexture(GL_TEXTURE_2D, texture);
-				GLint swizzleMask[4] = { GL_RED, GL_RED, GL_RED, GL_ONE };
-				glTexParameteriv(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_RGBA, swizzleMask);
-				glBindTexture(GL_TEXTURE_2D, 0);
+				texture.allocate(CAM_SX, CAM_SY, GX_R8_UNORM, false, true);
+				texture.upload(imageData, 1, CAM_SX);
+				texture.setSwizzle(0, 0, 0, GX_SWIZZLE_ONE);
 			}
 			else
 			{
-				texture = createTextureFromRGB8(imageData, CAM_SX, CAM_SY, false, true);
+				texture.allocate(CAM_SX, CAM_SY, GX_RGB8_UNORM, false, true);
+				texture.upload(imageData, 1, CAM_SX);
 			}
 		}
 		
 		framework.beginDraw(0, 0, 0, 0);
 		{
-			if (texture != 0)
+			if (texture.isValid())
 			{
 				pushBlend(BLEND_OPAQUE);
 				{
 					setColor(colorWhite);
-					gxSetTexture(texture);
+					gxSetTexture(texture.id);
 					drawRect(0, 0, CAM_SX, CAM_SY);
 					gxSetTexture(0);
 				}

--- a/framework/audio.cpp
+++ b/framework/audio.cpp
@@ -126,7 +126,7 @@ static void drawAudioHistory(const MyAudioCallback & audioCallback)
 
 int main(int argc, char * argv[])
 {
-	if (!framework.init(0, nullptr, 640, 480))
+	if (!framework.init(640, 480))
 		return -1;
 	
 	auto devices = PS3EYECam::getDevices();

--- a/framework/chibi.txt
+++ b/framework/chibi.txt
@@ -1,0 +1,19 @@
+# chibi build file for the chibi build system ~ https://github.com/marcel303/chibi
+
+cmake_module_path cmake_modules
+
+library libps3eye
+	
+	scan_files cpp path ../src group sources
+	scan_files h   path ../src group sources
+
+	header_path ../src expose
+
+	depend_package LibUSB
+
+app libps3eye-example
+
+	depend_library libps3eye
+	depend_library framework
+
+	add_files main.cpp

--- a/framework/chibi.txt
+++ b/framework/chibi.txt
@@ -11,9 +11,16 @@ library libps3eye
 
 	depend_package LibUSB
 
-app libps3eye-example
+app libps3eye-example-video
 
 	depend_library libps3eye
 	depend_library framework
 
-	add_files main.cpp
+	add_files video.cpp
+
+app libps3eye-example-audio
+
+	depend_library libps3eye
+	depend_library framework
+
+	add_files audio.cpp

--- a/framework/cmake_modules/FindLibUSB.cmake
+++ b/framework/cmake_modules/FindLibUSB.cmake
@@ -1,0 +1,103 @@
+# - Find libusb for portable USB support
+# 
+# If the LibUSB_ROOT environment variable
+# is defined, it will be used as base path.
+# The following standard variables get defined:
+#  LibUSB_FOUND:    true if LibUSB was found
+#  LibUSB_INCLUDE_DIR: the directory that contains the include file
+#  LibUSB_LIBRARIES:  the libraries
+
+IF(PKG_CONFIG_FOUND)
+  IF(DEPENDS_DIR) #Otherwise use System pkg-config path
+    SET(ENV{PKG_CONFIG_PATH} "$ENV{PKG_CONFIG_PATH}:${DEPENDS_DIR}/libusb/lib/pkgconfig")
+  ENDIF()
+  SET(MODULE "libusb-1.0")
+  IF(CMAKE_SYSTEM_NAME MATCHES "Linux")
+    SET(MODULE "libusb-1.0>=1.0.20")
+  ENDIF()
+  IF(LibUSB_FIND_REQUIRED)
+    SET(LibUSB_REQUIRED "REQUIRED")
+  ENDIF()
+  PKG_CHECK_MODULES(LibUSB ${LibUSB_REQUIRED} ${MODULE})
+
+  FIND_LIBRARY(LibUSB_LIBRARY
+    NAMES ${LibUSB_LIBRARIES}
+    HINTS ${LibUSB_LIBRARY_DIRS}
+  )
+  SET(LibUSB_LIBRARIES ${LibUSB_LIBRARY})
+
+  RETURN()
+ENDIF()
+
+FIND_PATH(LibUSB_INCLUDE_DIRS
+  NAMES libusb.h
+  PATHS
+    "${DEPENDS_DIR}/libusb"
+    "${DEPENDS_DIR}/libusbx"
+    ENV LibUSB_ROOT
+  PATH_SUFFIXES
+    include
+    libusb
+    include/libusb-1.0
+)
+
+SET(LIBUSB_NAME libusb)
+IF(WIN32)
+  INCLUDE(CheckCSourceRuns)
+  CHECK_C_SOURCE_RUNS("#include <windows.h>\nint main(){return !LoadLibraryA(\"libusbK\");}" LIBUSB_WITH_LIBUSBK)
+  CHECK_C_SOURCE_RUNS("#include <windows.h>\nint main(){return !LoadLibraryA(\"UsbDkHelper\");}" LIBUSB_WITH_USBDK)
+
+  IF(LIBUSB_USE_USBDK)
+    SET(LIBUSB_NAME libusb-usbdk)
+  ENDIF()
+
+  IF(LIBUSB_NAME MATCHES ^libusb-usbdk$ AND NOT LIBUSB_WITH_USBDK)
+    MESSAGE(WARNING "UsbDk device driver is not found. Fall back to libusbK.")
+    SET(LIBUSB_NAME libusb)
+  ENDIF()
+
+  IF(LIBUSB_NAME MATCHES ^libusb$ AND NOT LIBUSB_WITH_LIBUSBK)
+    MESSAGE(FATAL_ERROR "No USB device driver is installed.")
+  ENDIF()
+ENDIF()
+
+FIND_LIBRARY(LibUSB_LIBRARIES
+  NAMES ${LIBUSB_NAME}-1.0
+  PATHS
+    "${DEPENDS_DIR}/libusb"
+    "${DEPENDS_DIR}/libusbx"
+    ENV LibUSB_ROOT
+  PATH_SUFFIXES
+    x64/Release/dll
+    x64/Debug/dll
+    Win32/Release/dll
+    Win32/Debug/dll
+    MS64
+    MS64/dll
+)
+
+IF(WIN32)
+FIND_FILE(LibUSB_DLL
+  ${LIBUSB_NAME}-1.0.dll
+  PATHS
+    "${DEPENDS_DIR}/libusb"
+    "${DEPENDS_DIR}/libusbx"
+    ENV LibUSB_ROOT
+  PATH_SUFFIXES
+    x64/Release/dll
+    x64/Debug/dll
+    Win32/Release/dll
+    Win32/Debug/dll
+    MS64
+    MS64/dll
+)
+IF(LibUSB_DLL AND LIBUSB_USE_USBDK)
+  FILE(COPY ${LibUSB_DLL} DESTINATION ${CMAKE_BINARY_DIR})
+  SET(LibUSB_DLL ${CMAKE_BINARY_DIR}/libusb-1.0.dll)
+  FILE(RENAME ${CMAKE_BINARY_DIR}/${LIBUSB_NAME}-1.0.dll ${LibUSB_DLL})
+ENDIF()
+ENDIF()
+
+INCLUDE(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(LibUSB FOUND_VAR LibUSB_FOUND
+  REQUIRED_VARS LibUSB_LIBRARIES LibUSB_INCLUDE_DIRS)

--- a/framework/main.cpp
+++ b/framework/main.cpp
@@ -226,6 +226,8 @@ int main(int argc, char * argv[])
 		framework.endDraw();
 	}
 	
+	mic.shut();
+	
 	if (eye != nullptr)
 	{
 		eye->stop();

--- a/framework/main.cpp
+++ b/framework/main.cpp
@@ -1,10 +1,40 @@
 #include "framework.h"
 #include "ps3eye.h"
 
+#define CAM_SX 640
+#define CAM_SY 480
+#define CAM_FPS 60
+
+using namespace ps3eye;
+
+static std::string errorString;
+
+static uint8_t imageData[CAM_SX * CAM_SY * 3];
+
 int main(int argc, char * argv[])
 {
 	if (!framework.init(0, nullptr, 640, 480))
 		return -1;
+	
+	auto devices = PS3EYECam::getDevices();
+	
+	logInfo("found %d devices", devices.size());
+	
+	PS3EYECam::PS3EYERef eye;
+	
+	if (devices.empty())
+		errorString = "no PS3 eye camera found";
+	else
+		eye = devices[0];
+	
+	devices.clear();
+	
+	if (eye != nullptr && !eye->init(CAM_SX, CAM_SY, CAM_FPS, PS3EYECam::EOutputFormat::RGB))
+		errorString = "failed to initialize PS3 eye camera";
+	else
+		eye->start();
+	
+	GLuint texture = 0;
 	
 	while (!framework.quitRequested)
 	{
@@ -13,11 +43,37 @@ int main(int argc, char * argv[])
 		if (keyboard.wentDown(SDLK_ESCAPE))
 			framework.quitRequested = true;
 		
+		if (eye->isStreaming())
+		{
+			eye->getFrame(imageData);
+			
+			//
+			
+			if (texture != 0)
+				glDeleteTextures(1, &texture);
+			
+			texture = createTextureFromRGB8(imageData, CAM_SX, CAM_SY, false, true);
+		}
+		
 		framework.beginDraw(0, 0, 0, 0);
 		{
-		
+			setBlend(BLEND_OPAQUE);
+			
+			if (texture != 0)
+			{
+				setColor(colorWhite);
+				gxSetTexture(texture);
+				drawRect(0, 0, CAM_SX, CAM_SY);
+				gxSetTexture(0);
+			}
 		}
 		framework.endDraw();
+	}
+	
+	if (eye != nullptr)
+	{
+		eye->stop();
+		eye = nullptr;
 	}
 	
 	framework.shutdown();

--- a/framework/main.cpp
+++ b/framework/main.cpp
@@ -1,5 +1,6 @@
 #include "framework.h"
 #include "ps3eye.h"
+#include "ps3mic.h"
 
 #define CAM_SX 640
 #define CAM_SY 480
@@ -10,6 +11,27 @@ using namespace ps3eye;
 static std::string errorString;
 
 static uint8_t imageData[CAM_SX * CAM_SY * 3];
+
+struct MyAudioCallback : PS3EYEMic::AudioCallback
+{
+	virtual void handleAudioData(const int16_t * frames, const int numFrames) override
+	{
+		printf("received %d frames!\n", numFrames);
+	}
+};
+
+static void testAudioStreaming(PS3EYECam * eye)
+{
+	PS3EYEMic mic;
+	MyAudioCallback audioCallback;
+	
+	if (mic.init(eye->getDevice(), &audioCallback))
+	{
+		SDL_Delay(4000);
+		
+		mic.shut();
+	}
+}
 
 int main(int argc, char * argv[])
 {
@@ -28,6 +50,11 @@ int main(int argc, char * argv[])
 		eye = devices[0];
 	
 	devices.clear();
+	
+	if (eye != nullptr)
+	{
+		testAudioStreaming(eye.get());
+	}
 	
 	if (eye != nullptr && !eye->init(CAM_SX, CAM_SY, CAM_FPS, PS3EYECam::EOutputFormat::RGB))
 		errorString = "failed to initialize PS3 eye camera";

--- a/framework/main.cpp
+++ b/framework/main.cpp
@@ -17,44 +17,103 @@ static uint8_t imageData[CAM_SX * CAM_SY * 3];
 struct MyAudioCallback : AudioCallback
 {
 	std::vector<float> histories[4];
+	int maxHistoryFrames = 0;
+	int numHistoryFrames = 0;
+	int firstHistoryFrame = 0;
 	
 	MyAudioCallback(const float seconds)
 	{
-		const int numFramesToExpect = seconds * 16000;
-		const int numFramesToReserve = numFramesToExpect * 110 / 100;
+		maxHistoryFrames = seconds * PS3EYEMic::kSampleRate;
 		
 		for (int i = 0; i < 4; ++i)
-			histories[i].reserve(numFramesToReserve);
+		{
+			histories[i].resize(maxHistoryFrames, 0.f);
+		}
 	}
 	
 	virtual void handleAudioData(const AudioFrame * frames, const int numFrames) override
 	{
 		//printf("received %d frames!\n", numFrames);
 		
-		for (int c = 0; c < 4; ++c)
+		for (int i = 0; i < numFrames; ++i)
 		{
-			auto & history = histories[c];
-			
-			for (int i = 0; i < numFrames; ++i)
+			for (int c = 0; c < 4; ++c)
 			{
-				const float value = frames[i].channel[0] / float(1 << 15);
+				auto & history = histories[c];
 				
-				history.push_back(value);
+				const float value = frames[i].channel[c] / float(1 << 15);
+				
+				history[firstHistoryFrame] = value;
 			}
+			
+			if (numHistoryFrames < maxHistoryFrames)
+				numHistoryFrames++;
+			
+			firstHistoryFrame++;
+			
+			if (firstHistoryFrame == maxHistoryFrames)
+				firstHistoryFrame = 0;
 		}
 	}
 };
 
+static void drawAudioHistory(const MyAudioCallback & audioCallback)
+{
+	gxScalef(CAM_SX / float(audioCallback.maxHistoryFrames - 1), CAM_SY, 1.f);
+
+	for (int c = 0; c < 4; ++c)
+	{
+		auto & history = audioCallback.histories[c];
+		
+		gxPushMatrix();
+		{
+			gxTranslatef(0, (c + 1) / 5.f, 0);
+			gxScalef(1, 1 / 4.f, 1);
+			
+			const Color colors[4] =
+			{
+				colorRed,
+				colorGreen,
+				colorBlue,
+				colorYellow
+			};
+			
+			setColor(colors[c]);
+			hqBegin(HQ_LINES, true);
+			{
+				for (int i = audioCallback.firstHistoryFrame, n = 0; n + 1 < audioCallback.maxHistoryFrames; ++n)
+				{
+					const float value1 = history[i + 0];
+					const float value2 = history[i + 1];
+					const float strokeSize = .4f;
+					
+					hqLine(n + 0, value1, strokeSize, n + 1, value2, strokeSize);
+					
+					//
+					
+					i++;
+					
+					if (i == audioCallback.maxHistoryFrames)
+						i = 0;
+				}
+			}
+			hqEnd();
+		}
+		gxPopMatrix();
+	}
+}
+
 static void testAudioStreaming(PS3EYECam * eye)
 {
-	const int numSeconds = 10;
+	const int testDuration = 10; // seconds
+	const int historySize = 1; // seconds
 	
 	PS3EYEMic mic;
-	MyAudioCallback audioCallback(numSeconds);
+	MyAudioCallback audioCallback(historySize);
 	
 	if (mic.init(eye->getDevice(), &audioCallback))
 	{
-		const auto endTime = SDL_GetTicks() + numSeconds * 1000;
+		const auto endTime = SDL_GetTicks() + testDuration * 1000;
 		
 		while (SDL_GetTicks() < endTime && !keyboard.wentDown(SDLK_SPACE))
 		{
@@ -62,49 +121,7 @@ static void testAudioStreaming(PS3EYECam * eye)
 			
 			framework.beginDraw(0, 0, 0, 0);
 			{
-				auto & baseHistory = audioCallback.histories[0];
-				
-				if (baseHistory.size() < 2)
-					continue;
-				
-				const int numLines = std::min((int)baseHistory.size(), 16000 * 2/3);
-				const int offset = baseHistory.size() - numLines;
-				
-				gxScalef(CAM_SX / float(numLines - 1), CAM_SY, 1.f);
-				
-				for (int c = 0; c < 4; ++c)
-				{
-					auto & history = audioCallback.histories[c];
-					
-					gxPushMatrix();
-					{
-						gxTranslatef(0, (c + 1) / 5.f, 0);
-						gxScalef(1, 1 / 4.f, 1);
-						
-						const Color colors[4] =
-						{
-							colorRed,
-							colorGreen,
-							colorBlue,
-							colorYellow
-						};
-						
-						setColor(colors[c]);
-						hqBegin(HQ_LINES, true);
-						{
-							for (int i = 0; i + 1 < numLines; ++i)
-							{
-								const float value1 = history[i + offset + 0];
-								const float value2 = history[i + offset + 1];
-								const float strokeSize = .4f;
-								
-								hqLine(i + 0, value1, strokeSize, i + 1, value2, strokeSize);
-							}
-						}
-						hqEnd();
-					}
-					gxPopMatrix();
-				}
+				drawAudioHistory(audioCallback);
 			}
 			framework.endDraw();
 		}
@@ -133,7 +150,7 @@ int main(int argc, char * argv[])
 	
 	if (eye != nullptr)
 	{
-		testAudioStreaming(eye.get());
+		//testAudioStreaming(eye.get());
 	}
 	
 	if (eye != nullptr && !eye->init(CAM_SX, CAM_SY, CAM_FPS,
@@ -143,6 +160,14 @@ int main(int argc, char * argv[])
 		errorString = "failed to initialize PS3 eye camera";
 	else
 		eye->start();
+	
+	PS3EYEMic mic;
+	MyAudioCallback audioCallback(.5f);
+	
+	if (eye != nullptr)
+	{
+		mic.init(eye->getDevice(), &audioCallback);
+	}
 	
 	if (!errorString.empty())
 	{
@@ -184,15 +209,19 @@ int main(int argc, char * argv[])
 		
 		framework.beginDraw(0, 0, 0, 0);
 		{
-			setBlend(BLEND_OPAQUE);
-			
 			if (texture != 0)
 			{
-				setColor(colorWhite);
-				gxSetTexture(texture);
-				drawRect(0, 0, CAM_SX, CAM_SY);
-				gxSetTexture(0);
+				pushBlend(BLEND_OPAQUE);
+				{
+					setColor(colorWhite);
+					gxSetTexture(texture);
+					drawRect(0, 0, CAM_SX, CAM_SY);
+					gxSetTexture(0);
+				}
+				popBlend();
 			}
+			
+			drawAudioHistory(audioCallback);
 		}
 		framework.endDraw();
 	}

--- a/framework/main.cpp
+++ b/framework/main.cpp
@@ -176,13 +176,20 @@ int main(int argc, char * argv[])
 	}
 #endif
 	
-	if (eye != nullptr && !eye->init(CAM_SX, CAM_SY, CAM_FPS,
-		CAM_GRAYSCALE
-		? PS3EYECam::EOutputFormat::Gray
-		: PS3EYECam::EOutputFormat::RGB))
-		errorString = "failed to initialize PS3 eye camera";
-	else
-		eye->start();
+	if (eye != nullptr)
+	{
+		if (!eye->init(CAM_SX, CAM_SY, CAM_FPS,
+			CAM_GRAYSCALE
+			? PS3EYECam::EOutputFormat::Gray
+			: PS3EYECam::EOutputFormat::RGB))
+		{
+			errorString = "failed to initialize PS3 eye camera";
+		}
+		else
+		{
+			eye->start();
+		}
+	}
 	
 	PS3EYEMic mic;
 	MyAudioCallback audioCallback(AUDIO_HISTORY_LENGTH);
@@ -206,7 +213,7 @@ int main(int argc, char * argv[])
 		if (keyboard.wentDown(SDLK_ESCAPE))
 			framework.quitRequested = true;
 		
-		if (eye->isStreaming())
+		if (eye != nullptr && eye->isStreaming())
 		{
 			eye->getFrame(imageData);
 			

--- a/framework/main.cpp
+++ b/framework/main.cpp
@@ -100,18 +100,18 @@ static void drawAudioHistory(const MyAudioCallback & audioCallback)
 			{
 				for (int i = audioCallback.firstHistoryFrame, n = 0; n + 1 < audioCallback.maxHistoryFrames; ++n)
 				{
-					const float value1 = history[i + 0];
-					const float value2 = history[i + 1];
+					const int index1 = i;
+					const int index2 = i + 1 == audioCallback.maxHistoryFrames ? 0 : i + 1;
+					
+					const float value1 = history[index1];
+					const float value2 = history[index2];
 					const float strokeSize = .4f;
 					
 					hqLine(n + 0, value1, strokeSize, n + 1, value2, strokeSize);
 					
 					//
 					
-					i++;
-					
-					if (i == audioCallback.maxHistoryFrames)
-						i = 0;
+					i = index2;
 				}
 			}
 			hqEnd();

--- a/framework/main.cpp
+++ b/framework/main.cpp
@@ -1,0 +1,26 @@
+#include "framework.h"
+#include "ps3eye.h"
+
+int main(int argc, char * argv[])
+{
+	if (!framework.init(0, nullptr, 640, 480))
+		return -1;
+	
+	while (!framework.quitRequested)
+	{
+		framework.process();
+		
+		if (keyboard.wentDown(SDLK_ESCAPE))
+			framework.quitRequested = true;
+		
+		framework.beginDraw(0, 0, 0, 0);
+		{
+		
+		}
+		framework.endDraw();
+	}
+	
+	framework.shutdown();
+	
+	return 0;
+}

--- a/framework/video.cpp
+++ b/framework/video.cpp
@@ -15,7 +15,7 @@ static uint8_t imageData[CAM_SX * CAM_SY * 3];
 
 int main(int argc, char * argv[])
 {
-	if (!framework.init(0, nullptr, 640, 480))
+	if (!framework.init(640, 480))
 		return -1;
 	
 	auto devices = PS3EYECam::getDevices();

--- a/framework/video.cpp
+++ b/framework/video.cpp
@@ -1,0 +1,123 @@
+#include "framework.h"
+#include "ps3eye.h"
+
+#define CAM_SX 640
+#define CAM_SY 480
+#define CAM_FPS 60 // Frames per second. At 320x240 this can go as high as 187 fps.
+
+#define CAM_GRAYSCALE false // If true the camera will output a grayscale image instead of rgb color.
+
+using namespace ps3eye;
+
+static std::string errorString;
+
+static uint8_t imageData[CAM_SX * CAM_SY * 3];
+
+int main(int argc, char * argv[])
+{
+	if (!framework.init(0, nullptr, 640, 480))
+		return -1;
+	
+	auto devices = PS3EYECam::getDevices();
+	
+	logInfo("found %d devices", devices.size());
+	
+	PS3EYECam::PS3EYERef eye;
+	
+	if (devices.empty())
+		errorString = "no PS3 eye camera found";
+	else
+		eye = devices[0];
+	
+	devices.clear();
+	
+	if (eye != nullptr)
+	{
+		if (!eye->init(CAM_SX, CAM_SY, CAM_FPS,
+			CAM_GRAYSCALE
+			? PS3EYECam::EOutputFormat::Gray
+			: PS3EYECam::EOutputFormat::RGB))
+		{
+			errorString = "failed to initialize PS3 eye camera";
+		}
+		else
+		{
+			eye->start();
+		}
+	}
+	
+	if (!errorString.empty())
+	{
+		logError("error: %s", errorString.c_str());
+	}
+	
+	GLuint texture = 0;
+	
+	bool stressTest = false;
+	
+	while (!framework.quitRequested)
+	{
+		framework.process();
+		
+		if (keyboard.wentDown(SDLK_ESCAPE))
+			framework.quitRequested = true;
+		
+		if (keyboard.isDown(SDLK_LSHIFT) && keyboard.wentDown(SDLK_t))
+			stressTest = !stressTest;
+		
+		if (eye != nullptr && eye->isStreaming())
+		{
+			eye->getFrame(imageData);
+			
+			//
+			
+			if (texture != 0)
+				glDeleteTextures(1, &texture);
+			
+			if (CAM_GRAYSCALE)
+			{
+				texture = createTextureFromR8(imageData, CAM_SX, CAM_SY, false, true);
+				
+				glBindTexture(GL_TEXTURE_2D, texture);
+				GLint swizzleMask[4] = { GL_RED, GL_RED, GL_RED, GL_ONE };
+				glTexParameteriv(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_RGBA, swizzleMask);
+				glBindTexture(GL_TEXTURE_2D, 0);
+			}
+			else
+			{
+				texture = createTextureFromRGB8(imageData, CAM_SX, CAM_SY, false, true);
+			}
+		}
+		
+		framework.beginDraw(0, 0, 0, 0);
+		{
+			if (texture != 0)
+			{
+				pushBlend(BLEND_OPAQUE);
+				{
+					setColor(colorWhite);
+					gxSetTexture(texture);
+					drawRect(0, 0, CAM_SX, CAM_SY);
+					gxSetTexture(0);
+				}
+				popBlend();
+			}
+			
+			hqBegin(HQ_FILLED_CIRCLES);
+			setColor((eye != nullptr && eye->isStreaming()) ? colorGreen : colorRed);
+			hqFillCircle(14, 14, 10);
+			hqEnd();
+		}
+		framework.endDraw();
+	}
+	
+	if (eye != nullptr)
+	{
+		eye->stop();
+		eye = nullptr;
+	}
+	
+	framework.shutdown();
+	
+	return 0;
+}

--- a/framework/video.cpp
+++ b/framework/video.cpp
@@ -51,7 +51,7 @@ int main(int argc, char * argv[])
 		logError("error: %s", errorString.c_str());
 	}
 	
-	GLuint texture = 0;
+	GxTexture texture;
 	
 	bool stressTest = false;
 	
@@ -71,32 +71,27 @@ int main(int argc, char * argv[])
 			
 			//
 			
-			if (texture != 0)
-				glDeleteTextures(1, &texture);
-			
 			if (CAM_GRAYSCALE)
 			{
-				texture = createTextureFromR8(imageData, CAM_SX, CAM_SY, false, true);
-				
-				glBindTexture(GL_TEXTURE_2D, texture);
-				GLint swizzleMask[4] = { GL_RED, GL_RED, GL_RED, GL_ONE };
-				glTexParameteriv(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_RGBA, swizzleMask);
-				glBindTexture(GL_TEXTURE_2D, 0);
+				texture.allocate(CAM_SX, CAM_SY, GX_R8_UNORM, false, true);
+				texture.upload(imageData, 1, 0);
+				texture.setSwizzle(0, 0, 0, GX_SWIZZLE_ONE);
 			}
 			else
 			{
-				texture = createTextureFromRGB8(imageData, CAM_SX, CAM_SY, false, true);
+				texture.allocate(CAM_SX, CAM_SY, GX_RGB8_UNORM, false, true);
+				texture.upload(imageData, 1, 0);
 			}
 		}
 		
 		framework.beginDraw(0, 0, 0, 0);
 		{
-			if (texture != 0)
+			if (texture.isValid())
 			{
 				pushBlend(BLEND_OPAQUE);
 				{
 					setColor(colorWhite);
-					gxSetTexture(texture);
+					gxSetTexture(texture.id);
 					drawRect(0, 0, CAM_SX, CAM_SY);
 					gxSetTexture(0);
 				}

--- a/src/ps3eye.cpp
+++ b/src/ps3eye.cpp
@@ -1,6 +1,19 @@
 // source code from https://github.com/inspirit/PS3EYEDriver
 #include "ps3eye.h"
 
+// Get rid of annoying zero length structure warnings from libusb.h in MSVC
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4200)
+#endif
+
+#include "libusb.h"
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
 #include <thread>
 #include <mutex>
 #include <condition_variable>

--- a/src/ps3eye.cpp
+++ b/src/ps3eye.cpp
@@ -83,6 +83,12 @@
 #define snprintf _snprintf
 #endif
 
+#if defined(DEBUG) && 0
+#define debug(...) fprintf(stdout, __VA_ARGS__)
+#else
+#define debug(...)
+#endif
+
 namespace ps3eye {
 
 #define TRANSFER_SIZE		65536

--- a/src/ps3eye.cpp
+++ b/src/ps3eye.cpp
@@ -444,6 +444,16 @@ int USBMgr::listDevices( std::vector<PS3EYECam::PS3EYERef>& list )
     return cnt;
 }
 
+void micStarted()
+{
+	USBMgr::instance()->cameraStarted();
+}
+
+void micStopped()
+{
+	USBMgr::instance()->cameraStopped();
+}
+
 static void LIBUSB_CALL transfer_completed_callback(struct libusb_transfer *xfr);
 
 class FrameQueue

--- a/src/ps3eye.cpp
+++ b/src/ps3eye.cpp
@@ -18,6 +18,7 @@
 #include <mutex>
 #include <condition_variable>
 #include <atomic>
+#include <vector>
 
 #if defined WIN32 || defined _WIN32 || defined WINCE
 	#include <windows.h>

--- a/src/ps3eye.cpp
+++ b/src/ps3eye.cpp
@@ -545,8 +545,8 @@ public:
 		uint8_t*		dest_row		= outBuffer + dest_stride + 1; 	// We start outputting at the second pixel of the second row's G component
 		uint32_t R,G,B;
 		
-		// Fill rows 1 to height-1 of the destination buffer. First and last row are filled separately (they are copied from the second row and second-to-last rows respectively)
-		for (int y = 0; y < frame_height-1; source_row += source_stride, dest_row += dest_stride, ++y)
+		// Fill rows 1 to height-2 of the destination buffer. First and last row are filled separately (they are copied from the second row and second-to-last rows respectively)
+		for (int y = 0; y < frame_height-2; source_row += source_stride, dest_row += dest_stride, ++y)
 		{
 			const uint8_t* source		= source_row;
 			const uint8_t* source_end	= source + (source_stride-2);								// -2 to deal with the fact that we're starting at the second pixel of the row and should end at the second-to-last pixel of the row (first and last are filled separately)
@@ -646,8 +646,8 @@ public:
 		uint8_t*		dest_row				= outBuffer + dest_stride + num_output_channels + 1; 	// We start outputting at the second pixel of the second row's G component
 		int				swap_br					= inBGR ? 1 : -1;
 
-		// Fill rows 1 to height-1 of the destination buffer. First and last row are filled separately (they are copied from the second row and second-to-last rows respectively)
-		for (int y = 0; y < frame_height-1; source_row += source_stride, dest_row += dest_stride, ++y)
+		// Fill rows 1 to height-2 of the destination buffer. First and last row are filled separately (they are copied from the second row and second-to-last rows respectively)
+		for (int y = 0; y < frame_height-2; source_row += source_stride, dest_row += dest_stride, ++y)
 		{
 			const uint8_t* source		= source_row;
 			const uint8_t* source_end	= source + (source_stride-2);								// -2 to deal with the fact that we're starting at the second pixel of the row and should end at the second-to-last pixel of the row (first and last are filled separately)

--- a/src/ps3eye.cpp
+++ b/src/ps3eye.cpp
@@ -1248,6 +1248,10 @@ bool PS3EYECam::open_usb()
 		return false;
 	}
 
+	// Linux has a kernel module for the PS3 eye camera (that's where most of the code in here comes from..)
+	// so we must detach the driver before we can hook up with the eye ourselves
+	libusb_detach_kernel_driver(handle_, 0);
+
 	//libusb_set_configuration(handle_, 0);
 
 	res = libusb_claim_interface(handle_, 0);
@@ -1263,6 +1267,7 @@ void PS3EYECam::close_usb()
 {
 	debug("closing device\n");
 	libusb_release_interface(handle_, 0);
+	libusb_attach_kernel_driver(handle_, 0);
 	libusb_close(handle_);
 	libusb_unref_device(device_);
 	handle_ = NULL;

--- a/src/ps3eye.cpp
+++ b/src/ps3eye.cpp
@@ -821,6 +821,13 @@ public:
 		// Wait for cancelation to finish
 		num_active_transfers_condition.wait(lock, [this]() { return num_active_transfers == 0; });
 
+		// Free completed transfers
+		for (int index = 0; index < NUM_TRANSFERS; ++index)
+		{
+			libusb_free_transfer(xfr[index]);
+			xfr[index] = nullptr;
+		}
+		
 		USBMgr::instance()->cameraStopped();
 
 		free(transfer_buffer);
@@ -980,8 +987,7 @@ static void LIBUSB_CALL transfer_completed_callback(struct libusb_transfer *xfr)
     if (status != LIBUSB_TRANSFER_COMPLETED) 
     {
         debug("transfer status %d\n", status);
-
-        libusb_free_transfer(xfr);
+        
 		urb->transfer_canceled();
         
         if(status != LIBUSB_TRANSFER_CANCELLED)

--- a/src/ps3eye.cpp
+++ b/src/ps3eye.cpp
@@ -526,7 +526,7 @@ public:
 		uint32_t R,G,B;
 		
 		// Fill rows 1 to height-1 of the destination buffer. First and last row are filled separately (they are copied from the second row and second-to-last rows respectively)
-		for (int y = 0; y < frame_height-1; source_row += source_stride, dest_row += dest_stride, ++y)
+		for (int y = 0; y < frame_height-2; source_row += source_stride, dest_row += dest_stride, ++y)
 		{
 			const uint8_t* source		= source_row;
 			const uint8_t* source_end	= source + (source_stride-2);								// -2 to deal with the fact that we're starting at the second pixel of the row and should end at the second-to-last pixel of the row (first and last are filled separately)
@@ -627,7 +627,7 @@ public:
 		int				swap_br					= inBGR ? 1 : -1;
 
 		// Fill rows 1 to height-1 of the destination buffer. First and last row are filled separately (they are copied from the second row and second-to-last rows respectively)
-		for (int y = 0; y < frame_height-1; source_row += source_stride, dest_row += dest_stride, ++y)
+		for (int y = 0; y < frame_height-2; source_row += source_stride, dest_row += dest_stride, ++y)
 		{
 			const uint8_t* source		= source_row;
 			const uint8_t* source_end	= source + (source_stride-2);								// -2 to deal with the fact that we're starting at the second pixel of the row and should end at the second-to-last pixel of the row (first and last are filled separately)

--- a/src/ps3eye.cpp
+++ b/src/ps3eye.cpp
@@ -1015,7 +1015,7 @@ PS3EYECam::PS3EYECam(libusb_device *device)
 	greenblc = 128;
     flip_h = false;
     flip_v = false;
-
+    testPattern = false;
 	usb_buf = NULL;
 	handle_ = NULL;
 

--- a/src/ps3eye.h
+++ b/src/ps3eye.h
@@ -9,18 +9,8 @@
 
 #include <memory>
 
-// Get rid of annoying zero length structure warnings from libusb.h in MSVC
-
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4200)
-#endif
-
-#include "libusb.h"
-
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
+struct libusb_device;
+struct libusb_device_handle;
 
 #ifndef __STDC_CONSTANT_MACROS
 #  define __STDC_CONSTANT_MACROS

--- a/src/ps3eye.h
+++ b/src/ps3eye.h
@@ -161,6 +161,16 @@ public:
         sccb_reg_write(0x0c, val);
 	}
     
+    bool getTestPattern() const { return testPattern; }
+    void setTestPattern(bool enable)
+    {
+        testPattern = enable;
+        uint8_t val = sccb_reg_read(0x0C);
+        val &= ~0b00000001;
+        if (testPattern) val |= 0b00000001; // 0x80;
+        sccb_reg_write(0x0C, val);
+    }
+
 
     bool isStreaming() const { return is_streaming; }
     bool isInitialized() const { return device_ != NULL && handle_ != NULL && usb_buf != NULL; }
@@ -217,6 +227,7 @@ private:
 	uint8_t greenblc; // 0 <-> 255
     bool flip_h;
     bool flip_v;
+    bool testPattern;
 	//
     bool is_streaming;
 

--- a/src/ps3eye.h
+++ b/src/ps3eye.h
@@ -18,13 +18,6 @@ struct libusb_device_handle;
 
 #include <stdint.h>
 
-#if defined(DEBUG)
-#define debug(...) fprintf(stdout, __VA_ARGS__)
-#else
-#define debug(...) 
-#endif
-
-
 namespace ps3eye {
 
 class PS3EYECam

--- a/src/ps3eye.h
+++ b/src/ps3eye.h
@@ -144,6 +144,7 @@ public:
     bool isStreaming() const { return is_streaming; }
     bool isInitialized() const { return device_ != NULL && handle_ != NULL && usb_buf != NULL; }
 
+    libusb_device *getDevice() const { return device_; }
 	bool getUSBPortPath(char *out_identifier, size_t max_identifier_length) const;
 	
 	// Get a frame from the camera. Notes:

--- a/src/ps3eye.h
+++ b/src/ps3eye.h
@@ -2,12 +2,8 @@
 #ifndef PS3EYECAM_H
 #define PS3EYECAM_H
 
-#include <cstdio>
-#include <cstdlib>
-#include <cstring>
-#include <vector>
-
 #include <memory>
+#include <vector>
 
 struct libusb_device;
 struct libusb_device_handle;

--- a/src/ps3eye.h
+++ b/src/ps3eye.h
@@ -45,6 +45,8 @@ public:
 		Bayer,					// Output in Bayer. Destination buffer must be width * height bytes
 		BGR,					// Output in BGR. Destination buffer must be width * height * 3 bytes
 		RGB	,					// Output in RGB. Destination buffer must be width * height * 3 bytes
+		BGRA,					// Output in BGRA. Destination buffer must be width * height * 4 bytes
+		RGBA,					// Output in RGBA. Destination buffer must be width * height * 4 bytes
 		Gray					// Output in Grayscale. Destination buffer must be width * height bytes
 	};
 

--- a/src/ps3eye_capi.cpp
+++ b/src/ps3eye_capi.cpp
@@ -31,6 +31,7 @@
 #include "ps3eye.h"
 
 #include <list>
+#include <vector>
 
 struct ps3eye_context_t {
     ps3eye_context_t()

--- a/src/ps3mic.cpp
+++ b/src/ps3mic.cpp
@@ -1,0 +1,40 @@
+#include "ps3mic.h"
+#include <assert.h>
+
+void PS3EYEMic::init(libusb_device * _device, const AudioCallback * _audioCallback)
+{
+	assert(device == nullptr);
+	assert(audioCallback == nullptr);
+
+	device = _device;
+	audioCallback = _audioCallback;
+
+	// todo : find and claim interface
+
+	// todo : on Macos and Windows : suggest to unload kernel driver when interface claim fails
+}
+
+void PS3EYEMic::shut()
+{
+
+}
+
+void PS3EYEMic::beginTransfers(const int packetSize, const int numPackets, const int numTransfers)
+{
+
+}
+
+void PS3EYEMic::cancelTransfersBegin()
+{
+
+}
+
+void PS3EYEMic::cancelTransfersWait()
+{
+
+}
+
+void PS3EYEMic::freeTransfers()
+{
+	
+}

--- a/src/ps3mic.cpp
+++ b/src/ps3mic.cpp
@@ -46,6 +46,8 @@ extern void micStopped();
 
 //
 
+const int PS3EYEMic::kSampleRate = 16000;
+
 void PS3EYEMic::handleTransfer(struct libusb_transfer * transfer)
 {
 	PS3EYEMic * mic = (PS3EYEMic*)transfer->user_data;

--- a/src/ps3mic.cpp
+++ b/src/ps3mic.cpp
@@ -151,6 +151,11 @@ void PS3EYEMic::shut()
 	shutImpl();
 }
 
+bool PS3EYEMic::getIsInitialized() const
+{
+	return started == true;
+}
+
 bool PS3EYEMic::initImpl(libusb_device * _device, AudioCallback * _audioCallback)
 {
 	assert(device == nullptr);

--- a/src/ps3mic.cpp
+++ b/src/ps3mic.cpp
@@ -32,8 +32,6 @@ static const int ISO_ENDPOINT_ADDRESS = 0x84;
 
 /*
 For streaming we set up a bunch of transfers, which will each transfer a number of packets of a certain size. I have no idea what the ideal values are here. I guess there's a sweet spot between still having robust transfers while still maintaining an acceptable latency.
-
-todo : find good values for these numbers
 */
 static const int PACKET_SIZE = 1024;
 static const int NUM_PACKETS = 1;

--- a/src/ps3mic.cpp
+++ b/src/ps3mic.cpp
@@ -40,13 +40,10 @@ only has one capsule.
 
 //
 
-namespace ps3eye
-{
-	extern void micStarted();
-	extern void micStopped();
-}
+namespace ps3eye {
 
-using namespace ps3eye;
+extern void micStarted();
+extern void micStopped();
 
 //
 
@@ -74,7 +71,7 @@ static void handleTransfer(struct libusb_transfer * transfer)
 		
 		if (numFrames > 0)
 		{
-			const int16_t * frames = (int16_t*)libusb_get_iso_packet_buffer_simple(transfer, i);
+			const AudioFrame * frames = (AudioFrame*)libusb_get_iso_packet_buffer_simple(transfer, i);
 			
 			mic->audioCallback->handleAudioData(frames, numFrames);
 		}
@@ -309,4 +306,6 @@ void PS3EYEMic::freeTransfers()
 	
 	delete [] transferData;
 	transferData = nullptr;
+}
+
 }

--- a/src/ps3mic.cpp
+++ b/src/ps3mic.cpp
@@ -208,6 +208,7 @@ bool PS3EYEMic::initImpl(libusb_device * _device, AudioCallback * _audioCallback
 			);
 	#endif
 		// todo : add Windows help text here in case claiming the interface fails
+		// todo : test PS3 eye mic on Windows
 
 		debugMessage("failed to claim interface: %d: %s", res, libusb_error_name(res));
         return false;

--- a/src/ps3mic.cpp
+++ b/src/ps3mic.cpp
@@ -46,7 +46,7 @@ extern void micStopped();
 
 //
 
-static void handleTransfer(struct libusb_transfer * transfer)
+void PS3EYEMic::handleTransfer(struct libusb_transfer * transfer)
 {
 	PS3EYEMic * mic = (PS3EYEMic*)transfer->user_data;
 	
@@ -132,6 +132,11 @@ bool PS3EYEMic::init(libusb_device * device, AudioCallback * audioCallback)
 	return result;
 }
 
+void PS3EYEMic::shut()
+{
+	shutImpl();
+}
+
 bool PS3EYEMic::initImpl(libusb_device * _device, AudioCallback * _audioCallback)
 {
 	assert(device == nullptr);
@@ -215,7 +220,7 @@ bool PS3EYEMic::initImpl(libusb_device * _device, AudioCallback * _audioCallback
 	return true;
 }
 
-void PS3EYEMic::shut()
+void PS3EYEMic::shutImpl()
 {
 	if (numActiveTransfers > 0)
 	{

--- a/src/ps3mic.cpp
+++ b/src/ps3mic.cpp
@@ -35,9 +35,9 @@ For streaming we set up a bunch of transfers, which will each transfer a number 
 
 todo : find good values for these numbers
 */
-static const int PACKET_SIZE = 512;
-static const int NUM_PACKETS = 2;
-static const int NUM_TRANSFERS = 2;
+static const int PACKET_SIZE = 1024;
+static const int NUM_PACKETS = 1;
+static const int NUM_TRANSFERS = 4;
 
 //
 

--- a/src/ps3mic.cpp
+++ b/src/ps3mic.cpp
@@ -35,7 +35,7 @@ For streaming we set up a bunch of transfers, which will each transfer a number 
 
 todo : find good values for these numbers
 */
-static const int PACKET_SIZE = 256;
+static const int PACKET_SIZE = 512;
 static const int NUM_PACKETS = 2;
 static const int NUM_TRANSFERS = 2;
 
@@ -178,7 +178,14 @@ bool PS3EYEMic::initImpl(libusb_device * _device, AudioCallback * _audioCallback
 	res = libusb_claim_interface(deviceHandle, INTERFACE_NUMBER);
 	if (res != LIBUSB_SUCCESS)
 	{
-		// todo : on Macos and Windows : suggest to unload kernel driver when interface claim fails
+	#ifdef __APPLE__
+		printf(
+			"-- Failed to claim interface. On Macos this may be due to the OS already having loaded the Apple USB Audio kernel driver for your Eye camera. LibUSB cannot unload this driver for us, so you'll have to run the following command from the terminal to unload it manually. Note this will kill audio to/from ALL USB audio devices!!:\n"
+			"sudo kextunload -b com.apple.driver.AppleUSBAudio\n"
+			"--\n"
+			);
+	#endif
+		// todo : add Windows help text here in case claiming the interface fails
 
 		debugMessage("failed to claim interface: %d: %s", res, libusb_error_name(res));
         return false;
@@ -272,8 +279,6 @@ bool PS3EYEMic::beginTransfers(const int packetSize, const int numPackets, const
 			debugMessage("failed to allocate transfer");
 			return false;
 		}
-		
-		// todo : check result codes
 		
 		libusb_fill_iso_transfer(
 			transfer,

--- a/src/ps3mic.cpp
+++ b/src/ps3mic.cpp
@@ -1,7 +1,50 @@
+#include "ps3eye.h" // for vendor and product IDs
 #include "ps3mic.h"
-#include <assert.h>
 
-void PS3EYEMic::init(libusb_device * _device, const AudioCallback * _audioCallback)
+#include "libusb.h"
+
+#include <assert.h>
+#include <stdio.h>
+
+/*
+
+The PS3 eye camera exposes its microphone array as a regular USB audio device with four channels
+
+Each USB device can expose one or more 'interface'. The PS3 eye camera exposes its video
+capabilities on interface 0. Its USB audio interface is exposed on interface 2 (INTERFACE_NUMBER).
+
+We set the audio interface to alt setting 1, which means 'mono' output, which actually means to
+output one or more mono streams. For reference: alt setting 0 is energy savings mode (disabled) and
+alt setting 2 is stereo mode, which always produces a stream of stereo frames, even if the mic
+only has one capsule.
+
+*/
+
+#if defined(DEBUG)
+	#define debug(...) do { fprintf(stdout, __VA_ARGS__); fprintf(stdout, "\n"); } while (false)
+#else
+	#define debug(...)
+#endif
+
+#define INTERFACE_NUMBER 2
+
+// for streaming we set up a bunch of transfers, which will each transfer a number of packets of a certain size
+// I have no idea what the ideal values are here.. I guess there's a sweet spot between still having robust transfers
+// while still maintaining an acceptable latency.
+// todo : find good values for these numbers
+#define PACKET_SIZE 128
+#define NUM_PACKETS 8
+#define NUM_TRANSFERS 2
+
+PS3EYEMic::PS3EYEMic()
+{
+}
+
+PS3EYEMic::~PS3EYEMic()
+{
+}
+
+bool PS3EYEMic::init(libusb_device * _device, const AudioCallback * _audioCallback)
 {
 	assert(device == nullptr);
 	assert(audioCallback == nullptr);
@@ -9,9 +52,57 @@ void PS3EYEMic::init(libusb_device * _device, const AudioCallback * _audioCallba
 	device = _device;
 	audioCallback = _audioCallback;
 
-	// todo : find and claim interface
+	// open the USB device
 
-	// todo : on Macos and Windows : suggest to unload kernel driver when interface claim fails
+	int res = libusb_open(device, &deviceHandle);
+	if (res != 0)
+	{
+		debug("device open error: %d: %s", res, libusb_error_name(res));
+		return false;
+	}
+
+	res = libusb_set_configuration(deviceHandle, 1);
+	if (res != 0)
+	{
+		debug("failed to set device configuration: %d: %s", res, libusb_error_name(res));
+		return false;
+	}
+
+	// before we claim the interface, we must first detach any kernel drivers that may use it
+
+    if (libusb_kernel_driver_active(deviceHandle, INTERFACE_NUMBER))
+    {
+        res = libusb_detach_kernel_driver(deviceHandle, INTERFACE_NUMBER);
+        if (res < 0)
+        {
+            debug("failed to detach kernel driver: %d: %s", res, libusb_error_name(res));
+            return false;
+        }
+    }
+
+	// claim interface
+
+	res = libusb_claim_interface(deviceHandle, INTERFACE_NUMBER);
+	if (res < 0)
+	{
+		// todo : on Macos and Windows : suggest to unload kernel driver when interface claim fails
+
+		debug("failed to claim interface: %d: %s", res, libusb_error_name(res));
+        return false;
+    }
+
+    // set the interface alt mode. 1 = (multi-channel) mono
+
+	res = libusb_set_interface_alt_setting(deviceHandle, INTERFACE_NUMBER, 1);
+	if (res < 0)
+	{
+		debug("failed to set interface alt setting: %d: %sn", res, libusb_error_name(res));
+        return false;
+	}
+	
+	beginTransfers(PACKET_SIZE, NUM_PACKETS, NUM_TRANSFERS);
+
+	return true;
 }
 
 void PS3EYEMic::shut()
@@ -36,5 +127,5 @@ void PS3EYEMic::cancelTransfersWait()
 
 void PS3EYEMic::freeTransfers()
 {
-	
+
 }

--- a/src/ps3mic.h
+++ b/src/ps3mic.h
@@ -78,6 +78,8 @@ public:
 	bool init(libusb_device * device, AudioCallback * audioCallback); // Initialize and begin capturing microphone data
 	void shut(); // End capturing microphone data and shutdown
 	
+	bool getIsInitialized() const;
+	
 private:
 	bool initImpl(libusb_device * device, AudioCallback * audioCallback);
 	void shutImpl();

--- a/src/ps3mic.h
+++ b/src/ps3mic.h
@@ -1,23 +1,26 @@
 #pragma once
 
+struct libusb_device;
+struct libusb_device_handle;
+
 struct PS3EYEMic
 {
 	struct AudioCallback
 	{
 		// numSamples = numFrames * 4, as the PS3 eye contains a microphone array of four capsules
 
-		virtual void handleAudioData(const int16_t * frames, const int numFrames);
+		virtual void handleAudioData(const int16_t * frames, const int numFrames) = 0;
 	};
 
 	libusb_device * device = nullptr;
-	libusb_device_handle * deviceHandle = nullptr
+	libusb_device_handle * deviceHandle = nullptr;
 
-	AudioCallback * audioCallback = nullptr;
+	const AudioCallback * audioCallback = nullptr;
 
 	PS3EYEMic();
 	~PS3EYEMic();
 
-	void init(libusb_device * device, const AudioCallback * audioCallback);
+	bool init(libusb_device * device, const AudioCallback * audioCallback);
 	void shut();
 
 	void beginTransfers(const int packetSize, const int numPackets, const int numTransfers);

--- a/src/ps3mic.h
+++ b/src/ps3mic.h
@@ -1,7 +1,11 @@
 #pragma once
 
+#include <atomic>
+#include <vector>
+
 struct libusb_device;
 struct libusb_device_handle;
+struct libusb_transfer;
 
 struct PS3EYEMic
 {
@@ -15,16 +19,23 @@ struct PS3EYEMic
 	libusb_device * device = nullptr;
 	libusb_device_handle * deviceHandle = nullptr;
 
-	const AudioCallback * audioCallback = nullptr;
+	AudioCallback * audioCallback = nullptr;
+	
+	uint8_t * transferData = nullptr;
+	
+	std::vector<libusb_transfer*> transfers;
+	std::atomic<int> numActiveTransfers;
 
 	PS3EYEMic();
 	~PS3EYEMic();
 
-	bool init(libusb_device * device, const AudioCallback * audioCallback);
+	bool init(libusb_device * device, AudioCallback * audioCallback);
 	void shut();
 
-	void beginTransfers(const int packetSize, const int numPackets, const int numTransfers);
+	bool beginTransfers(const int packetSize, const int numPackets, const int numTransfers);
 	void cancelTransfersBegin();
 	void cancelTransfersWait();
 	void freeTransfers();
+	
+	void poll();
 };

--- a/src/ps3mic.h
+++ b/src/ps3mic.h
@@ -70,6 +70,8 @@ private:
 	static void handleTransfer(struct libusb_transfer * transfer);
 
 public:
+	static const int kSampleRate;
+	
 	PS3EYEMic();
 	~PS3EYEMic();
 

--- a/src/ps3mic.h
+++ b/src/ps3mic.h
@@ -1,0 +1,27 @@
+#pragma once
+
+struct PS3EYEMic
+{
+	struct AudioCallback
+	{
+		// numSamples = numFrames * 4, as the PS3 eye contains a microphone array of four capsules
+
+		virtual void handleAudioData(const int16_t * frames, const int numFrames);
+	};
+
+	libusb_device * device = nullptr;
+	libusb_device_handle * deviceHandle = nullptr
+
+	AudioCallback * audioCallback = nullptr;
+
+	PS3EYEMic();
+	~PS3EYEMic();
+
+	void init(libusb_device * device, const AudioCallback * audioCallback);
+	void shut();
+
+	void beginTransfers(const int packetSize, const int numPackets, const int numTransfers);
+	void cancelTransfersBegin();
+	void cancelTransfersWait();
+	void freeTransfers();
+};

--- a/src/ps3mic.h
+++ b/src/ps3mic.h
@@ -25,7 +25,7 @@ struct PS3EYEMic
 	
 	std::vector<libusb_transfer*> transfers;
 	std::atomic<int> numActiveTransfers;
-	std::atomic<bool> cancelTransfers;
+	std::atomic<bool> endTransfers;
 
 	PS3EYEMic();
 	~PS3EYEMic();
@@ -35,7 +35,7 @@ struct PS3EYEMic
 	void shut();
 
 	bool beginTransfers(const int packetSize, const int numPackets, const int numTransfers);
-	void cancelTransfersBegin();
-	void cancelTransfersWait();
+	void endTransfersBegin();
+	void endTransfersWait();
 	void freeTransfers();
 };

--- a/src/ps3mic.h
+++ b/src/ps3mic.h
@@ -1,3 +1,22 @@
+/*
+
+PS3 eye routines for capturing audio input from the four-channel microphone array.
+
+Support and donate at,
+https://www.patreon.com/marcelsmit
+
+Code origionally written by Marcel Smit,
+Author of the Framework creative coding library,
+https://github.com/marcel303/framework
+
+Donated to the community to hack away with.
+
+If you want to support my efforts building a new creative coding library,
+an audio-visual patching system, tutorials and examples and ofcourse
+projects like these, please become a patron. :-)
+
+*/
+
 #pragma once
 
 #include <atomic>
@@ -7,15 +26,22 @@ struct libusb_device;
 struct libusb_device_handle;
 struct libusb_transfer;
 
+namespace ps3eye {
+
+struct AudioFrame
+{
+	int16_t channel[4];
+};
+
+struct AudioCallback
+{
+	// numSamples = numFrames * 4, as the PS3 eye contains a four-channel microphone array
+
+	virtual void handleAudioData(const AudioFrame * frames, const int numFrames) = 0;
+};
+
 struct PS3EYEMic
 {
-	struct AudioCallback
-	{
-		// numSamples = numFrames * 4, as the PS3 eye contains a microphone array of four capsules
-
-		virtual void handleAudioData(const int16_t * frames, const int numFrames) = 0;
-	};
-
 	libusb_device * device = nullptr;
 	libusb_device_handle * deviceHandle = nullptr;
 
@@ -39,3 +65,5 @@ struct PS3EYEMic
 	void endTransfersWait();
 	void freeTransfers();
 };
+
+}

--- a/src/ps3mic.h
+++ b/src/ps3mic.h
@@ -25,17 +25,17 @@ struct PS3EYEMic
 	
 	std::vector<libusb_transfer*> transfers;
 	std::atomic<int> numActiveTransfers;
+	std::atomic<bool> cancelTransfers;
 
 	PS3EYEMic();
 	~PS3EYEMic();
 
 	bool init(libusb_device * device, AudioCallback * audioCallback);
+	bool initImpl(libusb_device * device, AudioCallback * audioCallback);
 	void shut();
 
 	bool beginTransfers(const int packetSize, const int numPackets, const int numTransfers);
 	void cancelTransfersBegin();
 	void cancelTransfersWait();
 	void freeTransfers();
-	
-	void poll();
 };

--- a/src/ps3mic.h
+++ b/src/ps3mic.h
@@ -15,13 +15,8 @@ If you want to support my efforts building a new creative coding library,
 an audio-visual patching system, tutorials and examples and ofcourse
 projects like these, please become a patron. :-)
 
-todo :
-
-- 48kHz sampling rate
+todo : 48kHz sampling rate
 	Marketing materials, Wikipedia etc all consistently say the PS3 Eye camera supports a 48kHz sampling rate. However, the USB audio class descriptor only mentions support for up to 16kHz, and this is what I get. Perhaps it's possible to switch modes? There's a mysterious vendor specific interface in the USB interface descriptor list. Perhaps this is the key?
-
-- Combine PS3 eye camera feed with microphone array input
-	This should be trivial to accomplish once all of the building blocks are in place.
 
 */
 

--- a/src/ps3mic.h
+++ b/src/ps3mic.h
@@ -15,6 +15,14 @@ If you want to support my efforts building a new creative coding library,
 an audio-visual patching system, tutorials and examples and ofcourse
 projects like these, please become a patron. :-)
 
+todo :
+
+- 48kHz sampling rate
+	Marketing materials, Wikipedia etc all consistently say the PS3 Eye camera supports a 48kHz sampling rate. However, the USB audio class descriptor only mentions support for up to 16kHz, and this is what I get. Perhaps it's possible to switch modes? There's a mysterious vendor specific interface in the USB interface descriptor list. Perhaps this is the key?
+
+- Combine PS3 eye camera feed with microphone array input
+	This should be trivial to accomplish once all of the building blocks are in place.
+
 */
 
 #pragma once
@@ -44,6 +52,7 @@ struct PS3EYEMic
 {
 	libusb_device * device = nullptr;
 	libusb_device_handle * deviceHandle = nullptr;
+	bool started = false;
 
 	AudioCallback * audioCallback = nullptr;
 	
@@ -56,9 +65,9 @@ struct PS3EYEMic
 	PS3EYEMic();
 	~PS3EYEMic();
 
-	bool init(libusb_device * device, AudioCallback * audioCallback);
+	bool init(libusb_device * device, AudioCallback * audioCallback); // Initialize and begin capturing microphone data
 	bool initImpl(libusb_device * device, AudioCallback * audioCallback);
-	void shut();
+	void shut(); // End capturing microphone data and shutdown
 
 	bool beginTransfers(const int packetSize, const int numPackets, const int numTransfers);
 	void endTransfersBegin();

--- a/src/ps3mic.h
+++ b/src/ps3mic.h
@@ -28,6 +28,8 @@ todo :
 #pragma once
 
 #include <atomic>
+#include <condition_variable>
+#include <mutex>
 #include <vector>
 
 struct libusb_device;
@@ -59,7 +61,9 @@ struct PS3EYEMic
 	uint8_t * transferData = nullptr;
 	
 	std::vector<libusb_transfer*> transfers;
-	std::atomic<int> numActiveTransfers;
+	int numActiveTransfers = 0;
+	std::mutex numActiveTransfersMutex;
+	std::condition_variable numActiveTransfersCondition;
 	std::atomic<bool> endTransfers;
 
 	PS3EYEMic();

--- a/src/ps3mic.h
+++ b/src/ps3mic.h
@@ -50,8 +50,9 @@ struct AudioCallback
 	virtual void handleAudioData(const AudioFrame * frames, const int numFrames) = 0;
 };
 
-struct PS3EYEMic
+class PS3EYEMic
 {
+private:
 	libusb_device * device = nullptr;
 	libusb_device_handle * deviceHandle = nullptr;
 	bool started = false;
@@ -65,13 +66,19 @@ struct PS3EYEMic
 	std::mutex numActiveTransfersMutex;
 	std::condition_variable numActiveTransfersCondition;
 	std::atomic<bool> endTransfers;
+	
+	static void handleTransfer(struct libusb_transfer * transfer);
 
+public:
 	PS3EYEMic();
 	~PS3EYEMic();
 
 	bool init(libusb_device * device, AudioCallback * audioCallback); // Initialize and begin capturing microphone data
-	bool initImpl(libusb_device * device, AudioCallback * audioCallback);
 	void shut(); // End capturing microphone data and shutdown
+	
+private:
+	bool initImpl(libusb_device * device, AudioCallback * audioCallback);
+	void shutImpl();
 
 	bool beginTransfers(const int packetSize, const int numPackets, const int numTransfers);
 	void endTransfersBegin();


### PR DESCRIPTION
A couple of small improvements I made while implementing a DirectShow filter based on this code. The RGB debayer function was extended to RGBA using a template so that two versions of the function are compiled. This was done with the idea that having a static number of channels may help the compiler optimize this function better and also it avoids having to check if the alpha channel should be set for every pixel.