### PR TITLE
Migrate deprecated function, auto-detach kernel driver on Linux

### DIFF
--- a/src/ps3eye.cpp
+++ b/src/ps3eye.cpp
@@ -1223,6 +1223,7 @@ bool PS3EYECam::open_usb()
 {
 	// open, set first config and claim interface
 	int res = libusb_open(device_, &handle_);
+	libusb_set_auto_detach_kernel_driver(handle_, 1);
 	if(res != 0) {
 		debug("device open error: %d\n", res);
 		return false;

--- a/src/ps3eye.cpp
+++ b/src/ps3eye.cpp
@@ -330,7 +330,7 @@ USBMgr::USBMgr()
 	exit_signaled = false;
 	active_camera_count = 0;
     libusb_init(&usb_context);
-    libusb_set_debug(usb_context, 1);
+    libusb_set_option(usb_context, LIBUSB_OPTION_LOG_LEVEL, 1);
 }
 
 USBMgr::~USBMgr()


### PR DESCRIPTION
This PR comes with two commits.

The first one fixes a compiler warning, because `libusb_set_debug()` is deprecated.

The second one allows PS3EYEDriver and the `gspca_ov534` native kernel driver on Linux to coexist -- while PS3EYEDriver is in use, the kernel driver gets detach, and re-attached after PS3EYEDriver is closed.